### PR TITLE
switch to opengl 4.5

### DIFF
--- a/assets/shaders/fragment.frag
+++ b/assets/shaders/fragment.frag
@@ -1,4 +1,4 @@
-#version 460 core
+#version 450 core
 
 in vec3 color;
 out vec4 fragColor;

--- a/assets/shaders/vertex.vert
+++ b/assets/shaders/vertex.vert
@@ -1,4 +1,4 @@
-#version 460 core
+#version 450 core
 
 in vec3 vertex;
 out vec3 color;

--- a/engine/game/mainloop.go
+++ b/engine/game/mainloop.go
@@ -5,7 +5,7 @@ import (
 	"math"
 
 	"github.com/Broyojo/minecraft-open-edition/engine/render"
-	"github.com/go-gl/gl/v4.6-core/gl"
+	"github.com/go-gl/gl/v4.5-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 

--- a/engine/render/mesh.go
+++ b/engine/render/mesh.go
@@ -1,6 +1,6 @@
 package render
 
-import "github.com/go-gl/gl/v4.6-core/gl"
+import "github.com/go-gl/gl/v4.5-core/gl"
 
 // TODO: refactor. not sure if my code is the best it can be
 

--- a/engine/render/shader.go
+++ b/engine/render/shader.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/go-gl/gl/v4.6-core/gl"
+	"github.com/go-gl/gl/v4.5-core/gl"
 )
 
 // Shader struct

--- a/engine/render/window.go
+++ b/engine/render/window.go
@@ -3,7 +3,7 @@ package render
 import (
 	"log"
 
-	"github.com/go-gl/gl/v4.6-core/gl"
+	"github.com/go-gl/gl/v4.5-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
@@ -14,7 +14,7 @@ func NewWindow(width, height int, name string) (*glfw.Window, error) {
 	}
 	glfw.WindowHint(glfw.Resizable, glfw.False)
 	glfw.WindowHint(glfw.ContextVersionMajor, 4)
-	glfw.WindowHint(glfw.ContextVersionMinor, 6)
+	glfw.WindowHint(glfw.ContextVersionMinor, 5)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
 	window, err := glfw.CreateWindow(width, height, name, nil, nil)

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,7 @@
 github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7 h1:SCYMcCJ89LjRGwEa0tRluNRiMjZHalQZrVrvTbPh+qw=
 github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7/go.mod h1:482civXOzJJCPzJ4ZOX/pwvXBWSnzD4OKMdH4ClKGbk=
-github.com/go-gl/glfw v0.0.0-20200707082815-5321531c36a2 h1:tCvD9jzwA40XAvO3wIhY748dWrXyNJ0mDQ3pTvlHlXQ=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200707082815-5321531c36a2 h1:Ac1OEHHkbAZ6EUnJahF0GKcU0FjPc/V8F1DvjhKngFE=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200707082815-5321531c36a2/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-gl/mathgl v1.0.0 h1:t9DznWJlXxxjeeKLIdovCOVJQk/GzDEL7h/h+Ro2B68=
 github.com/go-gl/mathgl v1.0.0/go.mod h1:yhpkQzEiH9yPyxDUGzkmgScbaBVlhC06qodikEM0ZwQ=
-golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f h1:FO4MZ3N56GnxbqxGKqh+YTzUWQ2sDwtFQEZgLOxh9Jc=
 golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
My machine doesn't appear to have drivers for opengl 4.6 (and possibly other machines), so switching some of the version strings used in code to version 4.5 allows it to compile on my machine, and is presumably OpenGL 4.6 has back-compat for 4.5 programs (do not quote me on this, please test before hand).

Alternatively, we could just switch to 3.x versions to guarantee compatiblity lol